### PR TITLE
add OnBot/Blocks helper class to allow access outside of Android op-modes

### DIFF
--- a/OnBotJavaBlocksHelper/NeoLEDsBlocks.java
+++ b/OnBotJavaBlocksHelper/NeoLEDsBlocks.java
@@ -1,0 +1,88 @@
+package org.firstinspires.ftc.teamcode;
+
+import org.firstinspires.ftc.robotcore.external.BlocksOpModeCompanion;
+import org.firstinspires.ftc.robotcore.external.ExportToBlocks;
+
+import java.lang.reflect.Method;
+import android.graphics.Color;
+
+public class NeoLEDsBlocks extends BlocksOpModeCompanion {
+
+    private static Object neoleds = null;
+    private static Method fill = null;
+    private static Method show = null;
+    private static Method setPixelColor = null;
+    private static Method setPixelColors = null;
+    
+    private static int[] pixelColors = null;
+
+    @ExportToBlocks (
+        comment = "Call this to setup the LEDs",
+        parameterLabels = {"Name of device in robot config", "Number of LEDs to use" }
+    )
+    public static void setLEDCount(String name, int ledCount) {
+        try {
+            neoleds = hardwareMap.get(name);
+            if(neoleds != null) {
+                Class neoClass = neoleds.getClass();
+                Method initMethod = neoClass.getDeclaredMethod("setNumberOfPixels", new Class<?>[] {int.class} );
+                initMethod.invoke(neoleds, ledCount);
+                fill = neoClass.getDeclaredMethod("fill", new Class<?>[] {String.class} );
+                show = neoClass.getDeclaredMethod("show", new Class<?>[] {} );
+                setPixelColors = neoClass.getDeclaredMethod("setPixelColors", new Class<?>[] {int[].class} );
+                setPixelColor = neoClass.getDeclaredMethod("setPixelColor", new Class<?>[] {int.class, String.class} );
+                pixelColors = new int[ledCount];
+                for(int i = 0; i < pixelColors.length; i++) {
+                    pixelColors[i] = Color.parseColor("#000000");
+                }
+            }
+        } catch(Exception e) {
+            telemetry.addLine("Error updating LEDS:" + e.toString());
+        }
+    }
+    
+    @ExportToBlocks (
+        comment = "Set the LEDs to a single color",
+        parameterLabels = {"Hex Color Code" },
+        tooltip = "Format is '#RRGGBB', for example '#EE00000' is red and '#999900' is a yellow color"
+    )
+    public static void setColor(String colorCode) {
+        if(fill != null) {
+            try {
+                fill.invoke(neoleds, colorCode);
+                show.invoke(neoleds);
+            } catch(Exception e) {
+                telemetry.addLine("Error updating LEDS:" + e.toString());
+            }
+        }
+    }
+    
+    @ExportToBlocks (
+        comment = "Set a single LED color",
+        parameterLabels = {"LED number", "Hex Color Code" },
+        tooltip = "Counts from zero, Use color code like '#EE00000' for red"
+    )
+    public static void setSingleColorLED(int pixel, String colorCode) {
+        if(pixelColors != null) {
+            if(pixel > -1 && pixel < pixelColors.length) {
+                pixelColors[pixel] = Color.parseColor(colorCode);
+            }
+        }
+    }
+    
+    @ExportToBlocks (
+        comment = "Push color changes to LEDs",
+        tooltip = "call after setting single colors"
+    )
+    public static void updateLEDs() {
+        if(show != null && setPixelColors != null && pixelColors != null) {
+            try {
+                setPixelColors.invoke(neoleds, pixelColors);
+                show.invoke(neoleds);
+            } catch(Exception e) {
+                telemetry.addLine("Error updating LEDS:" + e.toString());
+            }
+        }
+    }
+    
+}

--- a/OnBotJavaBlocksHelper/README.md
+++ b/OnBotJavaBlocksHelper/README.md
@@ -1,0 +1,33 @@
+# FTC NeoDriver Blocks Helper
+
+This code allows using the NeoDriver in OnBotJava or Blocks.
+
+This only supports a single NEODriver device per robot to keep the code simple.
+
+## Installation
+
+First, follow the guide to get the driver installed on the robot and configure 
+the device.  Once the device is working with code via Android Studio, you can 
+upload the java class `NeoLEDsBlocks.java` in the OnBotJava tab when connected
+to the controller hub.
+
+After uploading, you can confirm under Blocks by going to the Java Classes 
+section in the side toolbar and seeing new blocks show up.
+
+## Usage
+
+The same steps apply for both OnBotJava and Blocks.
+
+In your init section, call `NeoLEDsBlocks.setLEDCount` with the name from robot
+config for the device and the number of LEDs connected.
+
+After setting the LED count, you can control the LEDS either by calling 
+`NeoLEDsBlocks.setColor` with an RGB string or setting individual LEDs using
+`NeoLEDsBlocks.setSingleColorLED` with the LED (zero-based) number and then
+calling `NeoLEDsBlocks.updateLEDs` once to update all LEDs.   `updateLEDs` is
+not needed when calling `setColor`.
+
+## Troubleshooting
+
+If the LEDs are not enabling, but you can see the activity light on the NEODriver
+flashing, you may need to reboot the robot and try the mode again.


### PR DESCRIPTION
Here is a way to use this great library with OnBotJava and Blocks.

Our team codes autonomous modes in Android, but teleop in Blocks to allow more members to contribute.   Accessing the java classes from and Android op-mode are not directly accessible.  This uses reflection on the object pulled from the hardware map to interact with the driver.